### PR TITLE
use event_date to sort events

### DIFF
--- a/content/eventos/meetup-2018-12-14.md
+++ b/content/eventos/meetup-2018-12-14.md
@@ -2,7 +2,7 @@
 title = "Meetup 14 de Diciembre 2018"
 date = "2018-12-25T23:23:27-06:00"
 draft = false
-event_date = "2018-01-11T17:30:00-05:00"
+event_date = "2018-12-14T17:30:00-05:00"
 event_place = "Fonda La Independencia"
 description = "Último meetup del año 2018"
 topics = ["Kanban", "Firebase", "User Experience", "CSS Grid", "Stack Overflow"]

--- a/content/eventos/meetup-2019-01-11.md
+++ b/content/eventos/meetup-2019-01-11.md
@@ -2,7 +2,7 @@
 title = "Meetup 11 de Enero 2019"
 date = "2018-12-25T23:23:27-06:00"
 draft = false
-event_date = "2018-01-11T17:30:00-05:00"
+event_date = "2019-01-11T17:30:00-05:00"
 event_place = "Centro Recreativo Xalapeño"
 description = "Primer Meetup de 2019"
 thumbnail = "/img/eventos/meetup-110119.png"

--- a/themes/xalapacode/layouts/eventos/list.html
+++ b/themes/xalapacode/layouts/eventos/list.html
@@ -9,7 +9,7 @@
   <main class="main">
     <div class="container">
       <div class="row">
-        {{ range (.Data.Pages.ByDate) }}
+        {{ range (.Pages.ByParam "event_date").Reverse }}
         <div class="col-33 post">
           <div class="post-title">
             <h1>

--- a/themes/xalapacode/layouts/partials/eventos.html
+++ b/themes/xalapacode/layouts/partials/eventos.html
@@ -1,7 +1,7 @@
 <section class="section events">
   <h2 class="events-title">Próximos eventos</h2>
   <div class="container">
-    {{ range first 1 (where .Data.Pages.ByDate "Type" "=" "eventos")}}
+    {{ range first 1 (where (.Pages.ByParam "event_date").Reverse "Type" "eventos" ) }}
       <div class="post-thumbnail">
         <a href="{{ .Permalink }}"><img src="{{ .Params.thumbnail }}" alt="Cartel del evento"></a>
       </div>


### PR DESCRIPTION
Justo en este momento los eventos aparecen en algún orden bien arbitrario, este pull-request los ordena por sus respectivas fechas en las que suceden para que los visitantes puedan ver algo un poco más estable.